### PR TITLE
fix: キャラクター一覧で 6～8 番目のキャラクター選択後にクラス一覧から「特殊」クラスを選択し、その後他のクラスを選択した場合に閃き可能な技が表示されないようにした

### DIFF
--- a/app/src/SparkFromChara.elm
+++ b/app/src/SparkFromChara.elm
@@ -133,8 +133,13 @@ update msg model =
                         }
 
                 Nothing ->
-                    -- TODO (issue #21) charaIndex = Nothing を追加
-                    ( { model | sparkType = Nothing, wazas = [] }, Cmd.none )
+                    ( { model
+                        | charaIndex = Nothing
+                        , sparkType = Nothing
+                        , wazas = []
+                      }
+                    , Cmd.none
+                    )
 
         SelectWeaponType weaponType ->
             let

--- a/app/src/SparkFromChara.elm
+++ b/app/src/SparkFromChara.elm
@@ -100,12 +100,10 @@ update msg model =
                         msg_ =
                             SelectChara <| ListEx.getAt charaIndex_ newCharas
                     in
-                    ( update msg_ { model | charas = newCharas } |> Tuple.first
-                    , Cmd.none
-                    )
+                    update msg_ { model | charas = newCharas }
 
                 Nothing ->
-                    ( { model | charas = [] }, Cmd.none )
+                    update (SelectChara Nothing) { model | charas = [] }
 
         SelectChara maybeChara ->
             case maybeChara of
@@ -133,13 +131,12 @@ update msg model =
                         }
 
                 Nothing ->
-                    ( { model
-                        | charaIndex = Nothing
-                        , sparkType = Nothing
-                        , wazas = []
-                      }
-                    , Cmd.none
-                    )
+                    update (SelectWaza Nothing)
+                        { model
+                            | charaIndex = Nothing
+                            , sparkType = Nothing
+                            , wazas = []
+                        }
 
         SelectWeaponType weaponType ->
             let

--- a/app/tests/SparkFromCharaTest.elm
+++ b/app/tests/SparkFromCharaTest.elm
@@ -90,8 +90,13 @@ updateOnSelectCharaTests =
     -- 閃き可能な技を設定
     [ test "キャラクターが指定されていない場合、空の技リストを Model に設定する" <|
         \_ ->
+            -- キャラクターの選択位置、選択中キャラクターの閃きタイプ、
             -- 技リストを空以外に設定
-            { initialModel | wazas = [ wazaParry ] }
+            { initialModel
+                | charaIndex = Just 0
+                , sparkType = Just Repos.SparkAxe
+                , wazas = [ wazaParry ]
+            }
                 |> update (SelectChara Nothing)
                 |> Tuple.first
                 |> pretty

--- a/app/tests/SparkFromCharaTest.elm
+++ b/app/tests/SparkFromCharaTest.elm
@@ -229,8 +229,11 @@ updateOnSelectWazaTests =
     -- 敵一覧は件数が多いため、先頭から数件を検証し、それらが一致すれば OK とする
     [ test "技が指定されていない場合、空の派生元の技と敵のリストを Model に設定する" <|
         \_ ->
-            -- 派生元の技と敵のリストを空以外に設定
-            { initialModel | allWazaEnemies = [ WazaEnemies wazaParry.waza [] ] }
+            -- 技の選択位置、派生元の技と敵のリストを空以外に設定
+            { initialModel
+                | wazaIndex = Just 0
+                , allWazaEnemies = [ WazaEnemies wazaParry.waza [] ]
+            }
                 |> update (SelectWaza Nothing)
                 |> Tuple.first
                 |> (\m -> ( m.wazaIndex, m.allWazaEnemies ))


### PR DESCRIPTION
#21