### PR TITLE
fix: 感電衝を選択時に派生元の技や敵一覧を表示する

### DIFF
--- a/app/src/Repository.elm
+++ b/app/src/Repository.elm
@@ -877,6 +877,7 @@ wazaDerivations_ =
     , WazaDerivation_ 4 107 24
     , WazaDerivation_ 4 108 48
     , WazaDerivation_ 4 109 32
+    , WazaDerivation_ 5 113 8
     , WazaDerivation_ 5 114 14
     , WazaDerivation_ 5 115 25
     , WazaDerivation_ 5 116 27


### PR DESCRIPTION
#31